### PR TITLE
Removed dependency on "Arduino.h"

### DIFF
--- a/src/Argument.h
+++ b/src/Argument.h
@@ -7,7 +7,7 @@
 #ifndef Argument_h
 #define Argument_h
 
-#include "Arduino.h" // String
+#include "StringCLI.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/Command.h
+++ b/src/Command.h
@@ -7,7 +7,7 @@
 #ifndef Command_h
 #define Command_h
 
-#include "Arduino.h"  // String
+#include "StringCLI.h"
 #include "Argument.h" // Argument
 
 #ifdef __cplusplus

--- a/src/CommandError.h
+++ b/src/CommandError.h
@@ -7,7 +7,7 @@
 #ifndef CommandError_h
 #define CommandError_h
 
-#include "Arduino.h" // String
+#include "StringCLI.h"
 #include "Command.h" // Command
 
 #ifdef __cplusplus

--- a/src/StringCLI.h
+++ b/src/StringCLI.h
@@ -1,0 +1,13 @@
+#ifndef StringCLI_h
+#define StringCLI_h
+
+#if defined(ARDUINO)
+    #include "Arduino.h"           // String
+#else
+    #include <string>              // std::string
+    #include <cstring>             // strlen()
+    typedef std::string String;
+    inline String F(String s) { return s; };
+#endif
+
+#endif // ifndef StringCLI_h


### PR DESCRIPTION
Hi Stefan,

This is a great library, thanks for posting this.
I'm using it in a non-Arduino embedded project, so I had to remove Arduino dependency.
I'm also about to refactor `malloc()`, so that the library can support static memory depending on user's choice. Would you be interested in those changes?

Cheers